### PR TITLE
Logout from auth0

### DIFF
--- a/00-Starter-Seed/app/config/security.yml
+++ b/00-Starter-Seed/app/config/security.yml
@@ -27,6 +27,7 @@ security:
             logout:
                 path: /auth0/logout
                 target: /
+                success_handler: logoutlistener
 
     access_control:
         - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/00-Starter-Seed/app/config/services.yml
+++ b/00-Starter-Seed/app/config/services.yml
@@ -29,6 +29,9 @@ services:
         public: true
         tags: ['controller.service_arguments']
 
+    logoutlistener:
+        class: AppBundle\Listener\LogoutListener
+
     # add more services, or override services that need manual wiring
     # AppBundle\Service\ExampleService:
     #     arguments:

--- a/00-Starter-Seed/src/AppBundle/Auth0ResourceOwner.php
+++ b/00-Starter-Seed/src/AppBundle/Auth0ResourceOwner.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle;
 
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -38,17 +37,11 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
     {
         parent::configureOptions($resolver);
 
-        $dotenv = new Dotenv();
-
-        if (!getenv('AUTH0_DOMAIN')) {
-            $dotenv->load(__DIR__ . '/../../.env');
-        }
-
         $resolver->setDefaults(array(
             'authorization_url' => '{base_url}/authorize',
             'access_token_url' => '{base_url}/oauth/token',
             'infos_url' => '{base_url}/userinfo',
-            'audience' => 'https://'.getenv('AUTH0_DOMAIN').'/userinfo',
+            'audience' => '{base_url}/userinfo',
         ));
 
         $resolver->setRequired(array(
@@ -62,5 +55,6 @@ class Auth0ResourceOwner extends GenericOAuth2ResourceOwner
         $resolver->setNormalizer('authorization_url', $normalizer);
         $resolver->setNormalizer('access_token_url', $normalizer);
         $resolver->setNormalizer('infos_url', $normalizer);
+        $resolver->setNormalizer('audience', $normalizer);
     }
 }

--- a/00-Starter-Seed/src/AppBundle/Listener/LogoutListener.php
+++ b/00-Starter-Seed/src/AppBundle/Listener/LogoutListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AppBundle\Listener;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
+
+class LogoutListener implements LogoutSuccessHandlerInterface
+{
+
+    /**
+     * Creates a Response object to send upon a successful logout.
+     *
+     * @return Response never null
+     */
+    public function onLogoutSuccess(Request $request)
+    {
+        $returnTo = $request->getSchemeAndHttpHost();
+        $logoutUrl = sprintf(
+            'https://%s/v2/logout?client_id=%s&returnTo=%s',
+            getenv('AUTH0_DOMAIN'),
+            getenv('AUTH0_CLIENT_ID'),
+            $returnTo);
+        return new RedirectResponse($logoutUrl);
+    }
+}


### PR DESCRIPTION
### Description

- Clear session at Auth0 authorization server calling `/v2/logout` endpoint when perform logout.
- Remove unnecesary use of `Dotenv` in `Auth0ResourceOwner.php` class.

### Type of change

- [ ] Bug fix (fix to an issue)
- [x] New feature (changes to functionality)
- [ ] Big change (fix or feature that would cause existing functionality to work as expected)

### Testing

- Hit login button.
- Perform login in Auth0 login page.
- Hit logout button.
- Hit login button. In Auth0 login page should prompt email/password instead of show the previously logged in user.

**Test Configuration**

* Framework version: 3.3.12
* Language version: 7.2
* Browser version: Chrome 72.0.3626.119
